### PR TITLE
Update build command for backend service deployment

### DIFF
--- a/.replit
+++ b/.replit
@@ -39,4 +39,4 @@ args = "npm run dev"
 waitForPort = 5000
 
 [agent]
-integrations = ["javascript_log_in_with_replit==1.0.0", "javascript_database==1.0.0", "javascript_supabase==1.0.0"]
+integrations = ["javascript_supabase==1.0.0", "javascript_database==1.0.0", "javascript_log_in_with_replit==1.0.0"]

--- a/render.yaml
+++ b/render.yaml
@@ -3,7 +3,7 @@ services:
     name: via-english-academy-backend
     env: node
     plan: starter
-    buildCommand: npm install && npm run build
+    buildCommand: npm install && npx esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist
     startCommand: npm run start
     envVars:
       - key: NODE_ENV


### PR DESCRIPTION
Modify the `buildCommand` in `render.yaml` to use `npx esbuild` for bundling the backend server entry point, replacing the previous `npm run build` which failed due to `vite` not being found.

Replit-Commit-Author: Agent
Replit-Commit-Session-Id: 0988f78e-e694-45f7-829c-dc0131ae249c
Replit-Commit-Checkpoint-Type: full_checkpoint
Replit-Commit-Screenshot-Url: https://storage.googleapis.com/screenshot-production-us-central1/a52605b2-6d22-4ab0-bd97-b67c08b042d3/0988f78e-e694-45f7-829c-dc0131ae249c/Cnf1syt