### PR TITLE
Remove function configurations to allow for build configurations

### DIFF
--- a/.replit
+++ b/.replit
@@ -39,4 +39,4 @@ args = "npm run dev"
 waitForPort = 5000
 
 [agent]
-integrations = ["javascript_supabase==1.0.0", "javascript_database==1.0.0", "javascript_log_in_with_replit==1.0.0"]
+integrations = ["javascript_database==1.0.0", "javascript_log_in_with_replit==1.0.0", "javascript_supabase==1.0.0"]

--- a/vercel.json
+++ b/vercel.json
@@ -1,10 +1,5 @@
 {
   "version": 2,
-  "functions": {
-    "app/**/*.{js,ts,jsx,tsx}": {
-      "maxDuration": 30
-    }
-  },
   "builds": [
     {
       "src": "client/package.json",


### PR DESCRIPTION
Remove the `functions` property from vercel.json to resolve conflict with the `builds` property.

Replit-Commit-Author: Agent
Replit-Commit-Session-Id: 0988f78e-e694-45f7-829c-dc0131ae249c
Replit-Commit-Checkpoint-Type: full_checkpoint
Replit-Commit-Screenshot-Url: https://storage.googleapis.com/screenshot-production-us-central1/a52605b2-6d22-4ab0-bd97-b67c08b042d3/0988f78e-e694-45f7-829c-dc0131ae249c/Cnf1syt