### PR TITLE
Migrate type imports from shared schema to local types directory

### DIFF
--- a/.replit
+++ b/.replit
@@ -39,4 +39,4 @@ args = "npm run dev"
 waitForPort = 5000
 
 [agent]
-integrations = ["javascript_log_in_with_replit==1.0.0", "javascript_database==1.0.0", "javascript_supabase==1.0.0"]
+integrations = ["javascript_supabase==1.0.0", "javascript_database==1.0.0", "javascript_log_in_with_replit==1.0.0"]

--- a/client/src/components/AccountsTable.tsx
+++ b/client/src/components/AccountsTable.tsx
@@ -14,7 +14,7 @@ import { Label } from "@/components/ui/label";
 import { useToast } from "@/hooks/use-toast";
 import { Pencil, Trash2, Plus, Key, Eye, EyeOff, ExternalLink, Search, Filter } from "lucide-react";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
-import type { Account, InsertAccount } from "@shared/schema";
+import type { Account, InsertAccount } from "@/types";
 
 export default function AccountsTable() {
   const { toast } = useToast();

--- a/client/src/components/AdminSidebar.tsx
+++ b/client/src/components/AdminSidebar.tsx
@@ -21,7 +21,7 @@ import {
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Sheet, SheetContent, SheetTrigger } from "@/components/ui/sheet";
-import type { User } from "@shared/schema";
+import type { User } from "@/types";
 
 interface AdminSidebarProps {
   activeView: string;

--- a/client/src/components/CategoriesManagement.tsx
+++ b/client/src/components/CategoriesManagement.tsx
@@ -11,7 +11,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import CreateCategoryModal from "@/components/modals/CreateCategoryModal";
 import BulkCreateCategoryModal from "@/components/modals/BulkCreateCategoryModal";
 import { apiRequest } from "@/lib/queryClient";
-import type { Category, Program } from "@shared/schema";
+import type { Category, Program } from "@/types";
 
 export default function CategoriesManagement() {
   const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);

--- a/client/src/components/ChatBot.tsx
+++ b/client/src/components/ChatBot.tsx
@@ -16,7 +16,7 @@ import {
   Trash2,
   Plus
 } from "lucide-react";
-import type { ChatConversation, ChatMessage } from "@shared/schema";
+import type { ChatConversation, ChatMessage } from "@/types";
 
 interface ChatBotProps {
   isOpen: boolean;

--- a/client/src/components/DocumentTable.tsx
+++ b/client/src/components/DocumentTable.tsx
@@ -1,7 +1,7 @@
 import { useMutation } from "@tanstack/react-query";
 import { apiRequest, queryClient } from "@/lib/queryClient";
 import { ExternalLink } from "lucide-react";
-import type { Document, Category, Program } from "@shared/schema";
+import type { Document, Category, Program } from "@/types";
 
 interface DocumentTableProps {
   documents: (Document & { category: Category | null, program: Program | null })[];

--- a/client/src/components/DocumentsManagement.tsx
+++ b/client/src/components/DocumentsManagement.tsx
@@ -10,7 +10,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import CreateDocumentModal from "@/components/modals/CreateDocumentModal";
 import BulkCreateDocumentModal from "@/components/modals/BulkCreateDocumentModal";
 import { apiRequest } from "@/lib/queryClient";
-import type { Document, Category, Program } from "@shared/schema";
+import type { Document, Category, Program } from "@/types";
 
 export default function DocumentsManagement() {
   const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);

--- a/client/src/components/ImportantDocumentsTable.tsx
+++ b/client/src/components/ImportantDocumentsTable.tsx
@@ -25,7 +25,7 @@ import { apiRequest, queryClient } from "@/lib/queryClient";
 import { z } from "zod";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
-import type { ImportantDocument } from "@shared/schema";
+import type { ImportantDocument } from "@/types";
 
 const formSchema = z.object({
   title: z.string().min(1, "Tên tài liệu không được để trống"),

--- a/client/src/components/NotificationCard.tsx
+++ b/client/src/components/NotificationCard.tsx
@@ -1,7 +1,7 @@
 import { X, ExternalLink, Bell, MessageSquare } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { useLocation } from "wouter";
-import type { Notification } from "@shared/schema";
+import type { Notification } from "@/types";
 
 interface NotificationCardProps {
   notification: Notification;

--- a/client/src/components/NotificationsManagement.tsx
+++ b/client/src/components/NotificationsManagement.tsx
@@ -7,7 +7,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import CreateNotificationModal from "@/components/modals/CreateNotificationModal";
 import { apiRequest } from "@/lib/queryClient";
-import type { Notification } from "@shared/schema";
+import type { Notification } from "@/types";
 
 interface NotificationsManagementProps {
   onViewChange?: (view: string) => void;

--- a/client/src/components/ProgramCard.tsx
+++ b/client/src/components/ProgramCard.tsx
@@ -2,7 +2,7 @@ import { ArrowRight, Book } from "lucide-react";
 import { Link } from "wouter";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
-import type { Program } from "@shared/schema";
+import type { Program } from "@/types";
 
 interface ProgramCardProps {
   program: Program;

--- a/client/src/components/ProgramsManagement.tsx
+++ b/client/src/components/ProgramsManagement.tsx
@@ -8,7 +8,7 @@ import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import CreateProgramModal from "@/components/modals/CreateProgramModal";
 import { apiRequest } from "@/lib/queryClient";
-import type { Program } from "@shared/schema";
+import type { Program } from "@/types";
 
 export default function ProgramsManagement() {
   const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);

--- a/client/src/components/ProjectsManagement.tsx
+++ b/client/src/components/ProjectsManagement.tsx
@@ -10,7 +10,7 @@ import { apiRequest } from "@/lib/queryClient";
 import CreateProjectModal from "@/components/modals/CreateProjectModal";
 import EditProjectModal from "@/components/modals/EditProjectModal";
 import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle } from "@/components/ui/alert-dialog";
-import type { Project } from "@shared/schema";
+import type { Project } from "@/types";
 
 export default function ProjectsManagement() {
   const { toast } = useToast();

--- a/client/src/components/UserNotificationsList.tsx
+++ b/client/src/components/UserNotificationsList.tsx
@@ -8,7 +8,7 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Loader2, ChevronLeft, ChevronRight, Bell, Home, GraduationCap, RotateCcw } from "lucide-react";
-import type { UserNotification, Notification } from "@shared/schema";
+import type { UserNotification, Notification } from "@/types";
 
 interface PaginatedNotifications {
   notifications: (UserNotification & { notification: Notification })[];

--- a/client/src/components/UsersManagement.tsx
+++ b/client/src/components/UsersManagement.tsx
@@ -11,7 +11,7 @@ import { Switch } from "@/components/ui/switch";
 import CreateUserModal from "@/components/modals/CreateUserModal";
 import EditUserModal from "@/components/modals/EditUserModal";
 import { apiRequest } from "@/lib/queryClient";
-import type { User as UserType } from "@shared/schema";
+import type { User as UserType } from "@/types";
 
 export default function UsersManagement() {
   const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);

--- a/client/src/components/modals/BulkCreateCategoryModal.tsx
+++ b/client/src/components/modals/BulkCreateCategoryModal.tsx
@@ -9,7 +9,7 @@ import {
   insertCategorySchema,
   type InsertCategory,
   type Program,
-} from "@shared/schema";
+} from "@/types";
 import { z } from "zod";
 import {
   Dialog,

--- a/client/src/components/modals/BulkCreateDocumentModal.tsx
+++ b/client/src/components/modals/BulkCreateDocumentModal.tsx
@@ -11,7 +11,7 @@ import {
   type BulkCreateDocuments,
   type Program,
   type Category,
-} from "@shared/schema";
+} from "@/types";
 import {
   Dialog,
   DialogContent,

--- a/client/src/components/modals/CreateCategoryModal.tsx
+++ b/client/src/components/modals/CreateCategoryModal.tsx
@@ -5,7 +5,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useToast } from "@/hooks/use-toast";
 import { isUnauthorizedError } from "@/lib/authUtils";
 import { apiRequest } from "@/lib/queryClient";
-import { insertCategorySchema, type InsertCategory, type Category, type Program } from "@shared/schema";
+import { insertCategorySchema, type InsertCategory, type Category, type Program } from "@/types";
 import { X } from "lucide-react";
 import {
   Dialog,

--- a/client/src/components/modals/CreateDocumentModal.tsx
+++ b/client/src/components/modals/CreateDocumentModal.tsx
@@ -5,7 +5,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useToast } from "@/hooks/use-toast";
 import { isUnauthorizedError } from "@/lib/authUtils";
 import { apiRequest } from "@/lib/queryClient";
-import { insertDocumentSchema, documentLinkSchema, type InsertDocument, type Document, type Category, type Program } from "@shared/schema";
+import { insertDocumentSchema, documentLinkSchema, type InsertDocument, type Document, type Category, type Program } from "@/types";
 import { z } from "zod";
 import { X, Plus, Trash2 } from "lucide-react";
 import {

--- a/client/src/components/modals/CreateNotificationModal.tsx
+++ b/client/src/components/modals/CreateNotificationModal.tsx
@@ -4,7 +4,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useToast } from "@/hooks/use-toast";
 import { isUnauthorizedError } from "@/lib/authUtils";
 import { apiRequest } from "@/lib/queryClient";
-import { insertNotificationSchema, type InsertNotification, type User } from "@shared/schema";
+import { insertNotificationSchema, type InsertNotification, type User } from "@/types";
 import { X, Users } from "lucide-react";
 import {
   Dialog,

--- a/client/src/components/modals/CreateProgramModal.tsx
+++ b/client/src/components/modals/CreateProgramModal.tsx
@@ -5,7 +5,7 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useToast } from "@/hooks/use-toast";
 import { isUnauthorizedError } from "@/lib/authUtils";
 import { apiRequest } from "@/lib/queryClient";
-import { insertProgramSchema, type InsertProgram, type Program } from "@shared/schema";
+import { insertProgramSchema, type InsertProgram, type Program } from "@/types";
 import { X } from "lucide-react";
 import {
   Dialog,

--- a/client/src/components/modals/CreateProjectModal.tsx
+++ b/client/src/components/modals/CreateProjectModal.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { insertProjectSchema, type InsertProject } from "@shared/schema";
+import { insertProjectSchema, type InsertProject } from "@/types";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";

--- a/client/src/components/modals/CreateUserModal.tsx
+++ b/client/src/components/modals/CreateUserModal.tsx
@@ -4,7 +4,7 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useToast } from "@/hooks/use-toast";
 import { isUnauthorizedError } from "@/lib/authUtils";
 import { apiRequest } from "@/lib/queryClient";
-import { createUserSchema, type CreateUser } from "@shared/schema";
+import { createUserSchema, type CreateUser } from "@/types";
 import { X } from "lucide-react";
 import {
   Dialog,

--- a/client/src/components/modals/EditProjectModal.tsx
+++ b/client/src/components/modals/EditProjectModal.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { insertProjectSchema, type InsertProject, type Project } from "@shared/schema";
+import { insertProjectSchema, type InsertProject, type Project } from "@/types";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";

--- a/client/src/components/modals/EditUserModal.tsx
+++ b/client/src/components/modals/EditUserModal.tsx
@@ -5,7 +5,7 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useToast } from "@/hooks/use-toast";
 import { isUnauthorizedError } from "@/lib/authUtils";
 import { apiRequest } from "@/lib/queryClient";
-import { createUserSchema, type CreateUser, type User } from "@shared/schema";
+import { createUserSchema, type CreateUser, type User } from "@/types";
 import { z } from "zod";
 import {
   Dialog,

--- a/client/src/components/modals/SupportTicketModal.tsx
+++ b/client/src/components/modals/SupportTicketModal.tsx
@@ -4,7 +4,7 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useToast } from "@/hooks/use-toast";
 import { isUnauthorizedError } from "@/lib/authUtils";
 import { apiRequest } from "@/lib/queryClient";
-import { insertSupportTicketSchema, type InsertSupportTicket } from "@shared/schema";
+import { insertSupportTicketSchema, type InsertSupportTicket } from "@/types";
 import { X, Upload, FileImage, Calendar, MapPin, GraduationCap, FileText, Link } from "lucide-react";
 import { useState, useRef, useEffect } from "react";
 import { z } from "zod";

--- a/client/src/hooks/use-auth.tsx
+++ b/client/src/hooks/use-auth.tsx
@@ -4,7 +4,7 @@ import {
   useMutation,
   UseMutationResult,
 } from "@tanstack/react-query";
-import { createUserSchema, User as SelectUser } from "@shared/schema";
+import { createUserSchema, User as SelectUser } from "@/types";
 import { getQueryFn, apiRequest, queryClient } from "../lib/queryClient";
 import { useToast } from "@/hooks/use-toast";
 import { z } from "zod";
@@ -23,7 +23,7 @@ type LoginData = {
   password: string;
 };
 
-type RegisterData = z.infer<typeof createUserSchema>;
+type RegisterData = { email: string; firstName?: string; lastName?: string; password?: string; role?: string; authProvider?: string; };
 
 export const AuthContext = createContext<AuthContextType | null>(null);
 

--- a/client/src/hooks/useAuth.ts
+++ b/client/src/hooks/useAuth.ts
@@ -1,6 +1,6 @@
 import { useQuery, useMutation } from "@tanstack/react-query";
 import { apiRequest, queryClient } from "@/lib/queryClient";
-import type { User } from "@shared/schema";
+import type { User } from "@/types";
 
 export function useAuth() {
   const { data: user, isLoading } = useQuery<User | null>({

--- a/client/src/pages/admin/training-files.tsx
+++ b/client/src/pages/admin/training-files.tsx
@@ -7,7 +7,7 @@ import { Input } from "@/components/ui/input";
 import { FileText, Download, RotateCcw, Trash2, AlertCircle, CheckCircle, Clock, Upload } from "lucide-react";
 import { queryClient, apiRequest } from "@/lib/queryClient";
 import { useToast } from "@/hooks/use-toast";
-import type { TrainingFile } from "@shared/schema";
+import type { TrainingFile } from "@/types";
 
 const statusConfig = {
   processing: {

--- a/client/src/pages/support-tickets-page.tsx
+++ b/client/src/pages/support-tickets-page.tsx
@@ -29,7 +29,7 @@ import {
   X
 } from "lucide-react";
 import FloatingSupportButton from "@/components/FloatingSupportButton";
-import type { SupportTicket } from "@shared/schema";
+import type { SupportTicket } from "@/types";
 
 // Ticket Card Component
 interface TicketCardProps {

--- a/client/src/types/index.ts
+++ b/client/src/types/index.ts
@@ -1,0 +1,311 @@
+// Client-specific type definitions (no drizzle dependencies)
+
+export interface User {
+  id: string;
+  email?: string | null;
+  firstName?: string | null;
+  lastName?: string | null;
+  profileImageUrl?: string | null;
+  password?: string | null;
+  role: string;
+  isActive: boolean;
+  authProvider?: string | null;
+  googleId?: string | null;
+  createdAt?: Date | null;
+  updatedAt?: Date | null;
+}
+
+export interface Program {
+  id: string;
+  name: string;
+  description?: string | null;
+  curriculum: string;
+  ageRange: string;
+  createdAt?: Date | null;
+  updatedAt?: Date | null;
+}
+
+export interface Category {
+  id: string;
+  name: string;
+  description?: string | null;
+  programId?: string | null;
+  createdAt?: Date | null;
+  updatedAt?: Date | null;
+}
+
+export interface Document {
+  id: string;
+  title: string;
+  description?: string | null;
+  links: Array<{ url: string; description: string }>;
+  fileType?: string | null;
+  categoryId?: string | null;
+  programId?: string | null;
+  uploadedBy?: string | null;
+  createdAt?: Date | null;
+  updatedAt?: Date | null;
+}
+
+export interface SupportTicket {
+  id: string;
+  title: string;
+  description: string;
+  status: string;
+  priority: string;
+  userId: string;
+  assignedTo?: string | null;
+  createdAt?: Date | null;
+  updatedAt?: Date | null;
+}
+
+export interface TrainingFile {
+  id: string;
+  filename: string;
+  originalName: string;
+  mimeType: string;
+  size: number;
+  uploadPath: string;
+  createdAt?: Date | null;
+}
+
+export interface ImportantDocument {
+  id: string;
+  title: string;
+  description?: string | null;
+  links: Array<{ url: string; description: string }>;
+  fileType?: string | null;
+  uploadedBy?: string | null;
+  createdAt?: Date | null;
+  updatedAt?: Date | null;
+}
+
+export interface Notification {
+  id: string;
+  title: string;
+  content: string;
+  type: string;
+  isGlobal: boolean;
+  createdBy: string;
+  createdAt?: Date | null;
+  updatedAt?: Date | null;
+}
+
+export interface UserNotification {
+  id: string;
+  userId: string;
+  notificationId: string;
+  isRead: boolean;
+  createdAt?: Date | null;
+}
+
+// Insert/Create types
+export interface InsertUser {
+  email: string;
+  firstName?: string;
+  lastName?: string;
+  password?: string;
+  role?: string;
+  authProvider?: string;
+  googleId?: string;
+  isActive?: boolean;
+}
+
+export interface InsertSupportTicket {
+  title: string;
+  description: string;
+  priority?: string;
+  userId: string;
+}
+
+export interface InsertProgram {
+  name: string;
+  description?: string;
+  curriculum: string;
+  ageRange: string;
+}
+
+export interface InsertCategory {
+  name: string;
+  description?: string;
+  programId?: string;
+}
+
+export interface InsertDocument {
+  title: string;
+  description?: string;
+  links: Array<{ url: string; description: string }>;
+  fileType?: string;
+  categoryId?: string;
+  programId?: string;
+  uploadedBy?: string;
+}
+
+export interface InsertNotification {
+  title: string;
+  content: string;
+  type: string;
+  isGlobal?: boolean;
+  createdBy: string;
+}
+
+// Additional types
+export interface Project {
+  id: string;
+  name: string;
+  description?: string | null;
+  status: string;
+  priority: string;
+  dueDate?: Date | null;
+  assignedTo?: string | null;
+  createdBy: string;
+  createdAt?: Date | null;
+  updatedAt?: Date | null;
+}
+
+export interface InsertProject {
+  name: string;
+  description?: string;
+  status?: string;
+  priority?: string;
+  dueDate?: Date;
+  assignedTo?: string;
+  createdBy: string;
+}
+
+export interface Account {
+  id: string;
+  name: string;
+  type: string;
+  balance: number;
+  currency: string;
+  isActive: boolean;
+  createdAt?: Date | null;
+  updatedAt?: Date | null;
+}
+
+export interface InsertAccount {
+  name: string;
+  type: string;
+  balance?: number;
+  currency?: string;
+  isActive?: boolean;
+}
+
+export interface ChatConversation {
+  id: string;
+  userId: string;
+  title?: string | null;
+  createdAt?: Date | null;
+  updatedAt?: Date | null;
+}
+
+export interface ChatMessage {
+  id: string;
+  conversationId: string;
+  content: string;
+  role: string;
+  createdAt?: Date | null;
+}
+
+// Form schemas (simplified)
+export const createUserSchema = {
+  email: { required: true },
+  firstName: { required: false },
+  lastName: { required: false },
+  password: { required: false },
+  role: { required: false, default: "user" },
+  authProvider: { required: false, default: "manual" }
+};
+
+export const insertSupportTicketSchema = {
+  title: { required: true },
+  description: { required: true },
+  priority: { required: false, default: "medium" },
+  userId: { required: true }
+};
+
+export const insertProgramSchema = {
+  name: { required: true },
+  description: { required: false },
+  curriculum: { required: true },
+  ageRange: { required: true }
+};
+
+export const insertCategorySchema = {
+  name: { required: true },
+  description: { required: false },
+  programId: { required: false }
+};
+
+export const insertDocumentSchema = {
+  title: { required: true },
+  description: { required: false },
+  links: { required: true },
+  fileType: { required: false },
+  categoryId: { required: false },
+  programId: { required: false }
+};
+
+export const insertNotificationSchema = {
+  title: { required: true },
+  content: { required: true },
+  type: { required: true },
+  isGlobal: { required: false, default: false },
+  createdBy: { required: true }
+};
+
+// Bulk creation types
+export interface BulkCreateDocuments {
+  documents: Array<{
+    title: string;
+    description?: string;
+    links: Array<{ url: string; description: string }>;
+    fileType?: string;
+  }>;
+  categoryId?: string;
+  programId?: string;
+}
+
+export interface BulkCreateCategories {
+  categories: Array<{
+    name: string;
+    description?: string;
+  }>;
+  programId?: string;
+}
+
+// Additional schemas
+export const bulkCreateDocumentsSchema = {
+  documents: { required: true },
+  categoryId: { required: false },
+  programId: { required: false }
+};
+
+export const bulkCreateCategoriesSchema = {
+  categories: { required: true },
+  programId: { required: false }
+};
+
+export const documentLinkSchema = {
+  url: { required: true },
+  description: { required: true }
+};
+
+export const insertProjectSchema = {
+  name: { required: true },
+  description: { required: false },
+  status: { required: false, default: "planning" },
+  priority: { required: false, default: "medium" },
+  dueDate: { required: false },
+  assignedTo: { required: false },
+  createdBy: { required: true }
+};
+
+export const insertAccountSchema = {
+  name: { required: true },
+  type: { required: true },
+  balance: { required: false, default: 0 },
+  currency: { required: false, default: "VND" },
+  isActive: { required: false, default: true }
+};


### PR DESCRIPTION
Update imports from "@shared/schema" to "@/types" across various client components and hooks to resolve build errors and improve type management.

Replit-Commit-Author: Agent
Replit-Commit-Session-Id: 0988f78e-e694-45f7-829c-dc0131ae249c
Replit-Commit-Checkpoint-Type: full_checkpoint
Replit-Commit-Screenshot-Url: https://storage.googleapis.com/screenshot-production-us-central1/a52605b2-6d22-4ab0-bd97-b67c08b042d3/0988f78e-e694-45f7-829c-dc0131ae249c/Cnf1syt