### PR TITLE
Remove unused Vercel function configuration

### DIFF
--- a/client/vercel.json
+++ b/client/vercel.json
@@ -1,9 +1,4 @@
 {
-  "functions": {
-    "client/src/pages/*.tsx": {
-      "memory": 1024
-    }
-  },
   "rewrites": [
     {
       "source": "/api/(.*)",


### PR DESCRIPTION
Remove the `functions` configuration from `vercel.json` as it was not matching any Serverless Functions and causing deployment errors.

Replit-Commit-Author: Agent
Replit-Commit-Session-Id: 0988f78e-e694-45f7-829c-dc0131ae249c
Replit-Commit-Checkpoint-Type: full_checkpoint
Replit-Commit-Screenshot-Url: https://storage.googleapis.com/screenshot-production-us-central1/a52605b2-6d22-4ab0-bd97-b67c08b042d3/0988f78e-e694-45f7-829c-dc0131ae249c/HJmA5J7